### PR TITLE
surprisedがToVrm0X→ToVrm10で相互変換されないので戻せるようにする

### DIFF
--- a/Packages/net.santarh.sth-vrm-util/Runtime/ExpressionWrapper/Internal/ExpressionKeyConverter.cs
+++ b/Packages/net.santarh.sth-vrm-util/Runtime/ExpressionWrapper/Internal/ExpressionKeyConverter.cs
@@ -6,11 +6,18 @@ namespace SthVrmUtil.Runtime.ExpressionWrapper.Internal
 {
     internal static class ExpressionKeyConverter
     {
+
+        private const string SurprisedKey = "surprised";
+
         public static ExpressionKey ToVrm10(this BlendShapeKey key)
         {
             switch (key.Preset)
             {
-                case BlendShapePreset.Unknown: return ExpressionKey.CreateCustom(key.Name);
+                case BlendShapePreset.Unknown:
+                    {
+                        if (key.Name == SurprisedKey) return ExpressionKey.CreateFromPreset(ExpressionPreset.surprised);
+                        return ExpressionKey.CreateCustom(key.Name);
+                    }
                 case BlendShapePreset.Neutral: return ExpressionKey.CreateFromPreset(ExpressionPreset.neutral);
                 case BlendShapePreset.A: return ExpressionKey.CreateFromPreset(ExpressionPreset.aa);
                 case BlendShapePreset.I: return ExpressionKey.CreateFromPreset(ExpressionPreset.ih);
@@ -42,7 +49,7 @@ namespace SthVrmUtil.Runtime.ExpressionWrapper.Internal
                 case ExpressionPreset.angry: return BlendShapeKey.CreateFromPreset(BlendShapePreset.Angry);
                 case ExpressionPreset.sad: return BlendShapeKey.CreateFromPreset(BlendShapePreset.Sorrow);
                 case ExpressionPreset.relaxed: return BlendShapeKey.CreateFromPreset(BlendShapePreset.Fun);
-                case ExpressionPreset.surprised: return BlendShapeKey.CreateUnknown("surprised");
+                case ExpressionPreset.surprised: return BlendShapeKey.CreateUnknown(SurprisedKey);
                 case ExpressionPreset.aa: return BlendShapeKey.CreateFromPreset(BlendShapePreset.A);
                 case ExpressionPreset.ih: return BlendShapeKey.CreateFromPreset(BlendShapePreset.I);
                 case ExpressionPreset.ou: return BlendShapeKey.CreateFromPreset(BlendShapePreset.U);


### PR DESCRIPTION
ExpressionKeyConverter内、ExpressionKeyをToVrm0X→ToVrm10と相互変換した際に、Surprisedに関してはデータに差が出てしまい元に戻らなくなってしまう現象が確認されました。

これは内部的に

ExpressionKey.CreateCustom(key.Name) ≠ ExpressionKey.CreateFromPreset(ExpressionPreset.surprised)

であるためと思われます。

この為、Surprisedを動かしても動作しないという結果につながることがあります。

これを回避するために、surprisedというキーを持つものはToVrm10内の分岐でExpressionPreset.surprisedに戻してあげる必要があります。

surprisedという名前を持つカスタムアニメーションを参照していた場合、問題が出る可能性はありますが、surprisedがVRM1.0に通常Expressionとして項目が存在する以上、わざわざ同名で作るとは考えにくいので実質的に影響範囲は低いと思われます。

プルリクエストの修正内容は上記の修正変換をToVrm10に組み込んだものとなります。